### PR TITLE
Refactor assign_quiz

### DIFF
--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -27,11 +27,6 @@ class AssignmentParticipant < Participant
     assignment.try :directory_path
   end
 
-  def assign_quiz(contributor, reviewer, _topic = nil)
-    quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
-    QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
-  end
-
   # all the participants in this assignment who have reviewed the team where this participant belongs
   def reviewers
     reviewers = []

--- a/app/models/quiz_assignment.rb
+++ b/app/models/quiz_assignment.rb
@@ -18,11 +18,6 @@ module QuizAssignment
     candidate_topics
   end
 
-  def assign_quiz_dynamically(reviewer, topic)
-    contributor = contributor_for_quiz(reviewer, topic)
-    reviewer.assign_quiz(contributor, reviewer, topic) unless contributor.nil?
-  end
-
   # Returns a contributor whose quiz is to be taken if available, otherwise will raise an error
   def contributor_for_quiz(reviewer, topic)
     raise "Please select a topic." if topics? and topic.nil?

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -19,15 +19,6 @@ describe AssignmentParticipant do
     end
   end
 
-  describe '#assign_quiz' do
-    it 'creates a new QuizResponseMap record' do
-      allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
-      expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
-      expect(QuizResponseMap.first.reviewee_id).to eq(1)
-      expect(QuizResponseMap.first.reviewer_id).to eq(2)
-    end
-  end
-
   describe '#reviewers' do
     it 'returns all the participants in this assignment who have reviewed the team where this participant belongs' do
       allow(ReviewResponseMap).to receive(:where).with('reviewee_id = ?', 1).and_return([response_map])


### PR DESCRIPTION
Changes:

* Removed all instances of assign_quiz method (defined in assignment_participant.rb)
* Removed all unused instances assign_quiz_dynamically (defined in quiz_assignment.rb)
-- Alternative assign_quiz_dynamically method located in review_mapping_controller.rb became the integral method used in    recent years

* Ensured all instances of assign_quiz_dynamically (review_mapping_controller.rb) were untouched and operational as expected 
-- This version does not invoke any assign_quiz method