### PR TITLE
Refactor grant_publishing_rights

### DIFF
--- a/app/controllers/publishing_controller.rb
+++ b/app/controllers/publishing_controller.rb
@@ -53,7 +53,9 @@ class PublishingController < ApplicationController
     private_key = params[:private_key]
 
     begin
-      AssignmentParticipant.assign_copyright(private_key, participants)
+      participants.each do |participant|
+        participant.assign_copyright(private_key)
+      end
       redirect_to action: 'view'
     rescue StandardError
       flash[:notice] = 'The private key you inputted was invalid.'

--- a/app/controllers/publishing_controller.rb
+++ b/app/controllers/publishing_controller.rb
@@ -53,7 +53,7 @@ class PublishingController < ApplicationController
     private_key = params[:private_key]
 
     begin
-      AssignmentParticipant.grant_publishing_rights(private_key, participants)
+      AssignmentParticipant.assign_copyright(private_key, participants)
       redirect_to action: 'view'
     rescue StandardError
       flash[:notice] = 'The private key you inputted was invalid.'

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -27,12 +27,6 @@ class AssignmentParticipant < Participant
     assignment.try :directory_path
   end
 
-  # refactor into quiz_questionnaire.rb ?
-  # def assign_quiz(contributor, reviewer, _topic = nil)
-  #   quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
-  #   QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
-  # end
-
   # all the participants in this assignment who have reviewed the team where this participant belongs
   def reviewers
     reviewers = []

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -214,15 +214,6 @@ class AssignmentParticipant < Participant
   # grant publishing rights to one or more assignments. Using the supplied private key,
   # digital signatures are generated.
   # reference: http://stuff-things.net/2008/02/05/encrypting-lots-of-sensitive-data-with-ruby-on-rails/
-  # def self.assign_copyright(private_key, participants)
-  #   participants.each do |participant|
-  #     # now, check to make sure the digital signature is valid, if not raise error
-  #     participant.permission_granted = participant.verify_digital_signature(private_key)
-  #     participant.save
-  #     raise 'Invalid key' unless participant.permission_granted
-  #   end
-  # end
-
   def assign_copyright(private_key)
     # now, check to make sure the digital signature is valid, if not raise error
     self.permission_granted = self.verify_digital_signature(private_key)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -214,7 +214,7 @@ class AssignmentParticipant < Participant
   # grant publishing rights to one or more assignments. Using the supplied private key,
   # digital signatures are generated.
   # reference: http://stuff-things.net/2008/02/05/encrypting-lots-of-sensitive-data-with-ruby-on-rails/
-  def assign_copyright(private_key, participants)
+  def self.assign_copyright(private_key, participants)
     participants.each do |participant|
       # now, check to make sure the digital signature is valid, if not raise error
       participant.permission_granted = participant.verify_digital_signature(private_key)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -27,10 +27,11 @@ class AssignmentParticipant < Participant
     assignment.try :directory_path
   end
 
-  def assign_quiz(contributor, reviewer, _topic = nil)
-    quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
-    QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
-  end
+  # refactor into quiz_questionnaire.rb ?
+  # def assign_quiz(contributor, reviewer, _topic = nil)
+  #   quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
+  #   QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
+  # end
 
   # all the participants in this assignment who have reviewed the team where this participant belongs
   def reviewers

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -140,7 +140,7 @@ class AssignmentParticipant < Participant
   end
 
   # Copy this participant to a course
-  def copy(course_id)
+  def copy_participant(course_id)
     CourseParticipant.find_or_create_by(user_id: self.user_id, parent_id: course_id)
   end
 
@@ -213,7 +213,7 @@ class AssignmentParticipant < Participant
   # grant publishing rights to one or more assignments. Using the supplied private key,
   # digital signatures are generated.
   # reference: http://stuff-things.net/2008/02/05/encrypting-lots-of-sensitive-data-with-ruby-on-rails/
-  def self.grant_publishing_rights(private_key, participants)
+  def assign_copyright(private_key, participants)
     participants.each do |participant|
       # now, check to make sure the digital signature is valid, if not raise error
       participant.permission_granted = participant.verify_digital_signature(private_key)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -214,13 +214,20 @@ class AssignmentParticipant < Participant
   # grant publishing rights to one or more assignments. Using the supplied private key,
   # digital signatures are generated.
   # reference: http://stuff-things.net/2008/02/05/encrypting-lots-of-sensitive-data-with-ruby-on-rails/
-  def self.assign_copyright(private_key, participants)
-    participants.each do |participant|
-      # now, check to make sure the digital signature is valid, if not raise error
-      participant.permission_granted = participant.verify_digital_signature(private_key)
-      participant.save
-      raise 'Invalid key' unless participant.permission_granted
-    end
+  # def self.assign_copyright(private_key, participants)
+  #   participants.each do |participant|
+  #     # now, check to make sure the digital signature is valid, if not raise error
+  #     participant.permission_granted = participant.verify_digital_signature(private_key)
+  #     participant.save
+  #     raise 'Invalid key' unless participant.permission_granted
+  #   end
+  # end
+
+  def assign_copyright(private_key)
+    # now, check to make sure the digital signature is valid, if not raise error
+    self.permission_granted = self.verify_digital_signature(private_key)
+    self.save
+    raise 'Invalid key' unless self.permission_granted  
   end
 
   # verify the digital signature is valid

--- a/app/models/quiz_assignment.rb
+++ b/app/models/quiz_assignment.rb
@@ -18,11 +18,6 @@ module QuizAssignment
     candidate_topics
   end
 
-  def assign_quiz_dynamically(reviewer, topic)
-    contributor = contributor_for_quiz(reviewer, topic)
-    reviewer.assign_quiz(contributor, reviewer, topic) unless contributor.nil?
-  end
-
   # Returns a contributor whose quiz is to be taken if available, otherwise will raise an error
   def contributor_for_quiz(reviewer, topic)
     raise "Please select a topic." if topics? and topic.nil?

--- a/app/models/quiz_questionnaire.rb
+++ b/app/models/quiz_questionnaire.rb
@@ -34,10 +34,4 @@ class QuizQuestionnaire < Questionnaire
     !ResponseMap.where(reviewed_object_id: self.id, type: 'QuizResponseMap', reviewer_id: participant.id).empty?
   end
 
-  # remove? - test quiz functionaly 
-  def assign_quiz(contributor, reviewer, _topic = nil)
-    quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
-    QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
-  end
-
 end

--- a/app/models/quiz_questionnaire.rb
+++ b/app/models/quiz_questionnaire.rb
@@ -33,4 +33,10 @@ class QuizQuestionnaire < Questionnaire
   def taken_by? participant
     !ResponseMap.where(reviewed_object_id: self.id, type: 'QuizResponseMap', reviewer_id: participant.id).empty?
   end
+
+  def assign_quiz(contributor, reviewer, _topic = nil)
+    quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
+    QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)
+  end
+
 end

--- a/app/models/quiz_questionnaire.rb
+++ b/app/models/quiz_questionnaire.rb
@@ -34,6 +34,7 @@ class QuizQuestionnaire < Questionnaire
     !ResponseMap.where(reviewed_object_id: self.id, type: 'QuizResponseMap', reviewer_id: participant.id).empty?
   end
 
+  # remove? - test quiz functionaly 
   def assign_quiz(contributor, reviewer, _topic = nil)
     quiz = QuizQuestionnaire.find_by(instructor_id: contributor.id)
     QuizResponseMap.create(reviewed_object_id: quiz.try(:id), reviewee_id: contributor.id, reviewer_id: reviewer.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -215,8 +215,8 @@ class User < ActiveRecord::Base
     # when replacing an existing key, update any digital signatures made previously with the new key
     if replacing_key
       participants = AssignmentParticipant.where(user_id: self.id)
-      for participant in participants
-        AssignmentParticipant.assign_copyright(new_key.to_pem, [participant]) if participant.permission_granted
+      participants.each do |participant|
+        participant.assign_copyright(new_key.to_pem) if participant.permission_granted
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,7 +216,7 @@ class User < ActiveRecord::Base
     if replacing_key
       participants = AssignmentParticipant.where(user_id: self.id)
       for participant in participants
-        AssignmentParticipant.grant_publishing_rights(new_key.to_pem, [participant]) if participant.permission_granted
+        AssignmentParticipant.assign_copyright(new_key.to_pem, [participant]) if participant.permission_granted
       end
     end
 

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -19,16 +19,6 @@ describe AssignmentParticipant do
     end
   end
 
-  # refactor into quiz_questionnaire_spec.rb ?
-  # describe '#assign_quiz' do
-  #   it 'creates a new QuizResponseMap record' do
-  #     allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
-  #     expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
-  #     expect(QuizResponseMap.first.reviewee_id).to eq(1)
-  #     expect(QuizResponseMap.first.reviewer_id).to eq(2)
-  #   end
-  # end
-
   describe '#reviewers' do
     it 'returns all the participants in this assignment who have reviewed the team where this participant belongs' do
       allow(ReviewResponseMap).to receive(:where).with('reviewee_id = ?', 1).and_return([response_map])

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -252,7 +252,7 @@ describe AssignmentParticipant do
       key = OpenSSL::PKey::RSA.new 2048
       participant.user.public_key = key.public_key.to_pem
 
-      participant.assign_copyright(key.private_key)
+      participant.assign_copyright(key)
       expect(participant.permission_granted).to eq(true) 
     end
   end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -19,14 +19,15 @@ describe AssignmentParticipant do
     end
   end
 
-  describe '#assign_quiz' do
-    it 'creates a new QuizResponseMap record' do
-      allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
-      expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
-      expect(QuizResponseMap.first.reviewee_id).to eq(1)
-      expect(QuizResponseMap.first.reviewer_id).to eq(2)
-    end
-  end
+  # refactor into quiz_questionnaire_spec.rb ?
+  # describe '#assign_quiz' do
+  #   it 'creates a new QuizResponseMap record' do
+  #     allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
+  #     expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
+  #     expect(QuizResponseMap.first.reviewee_id).to eq(1)
+  #     expect(QuizResponseMap.first.reviewer_id).to eq(2)
+  #   end
+  # end
 
   describe '#reviewers' do
     it 'returns all the participants in this assignment who have reviewed the team where this participant belongs' do
@@ -188,9 +189,9 @@ describe AssignmentParticipant do
     end
   end
 
-  describe '#copy' do
+  describe '#copy_participant' do
     it 'copies assignment participants to a certain course' do
-      expect { participant.copy(123) }.to change { CourseParticipant.count }.from(0).to(1)
+      expect { participant.copy_participant(123) }.to change { CourseParticipant.count }.from(0).to(1)
       expect(CourseParticipant.first.user_id).to eq(2)
       expect(CourseParticipant.first.parent_id).to eq(123)
     end
@@ -329,6 +330,8 @@ describe AssignmentParticipant do
       )
     end
   end
+
+
 
   describe '#set_handle' do
     let(:student) { build(:student, name: 'no one') }

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -246,6 +246,17 @@ describe AssignmentParticipant do
     end
   end
 
+  describe '#assign_copyright' do
+    it 'grant publishing rights to one or more assignments using the supplied private key' do
+      # create new RSA key-pair 
+      key = OpenSSL::PKey::RSA.new 2048
+      participant.public_key = key.public_key.to_pem
+
+      participant.assign_copyright(key.private_key)
+      expect(participant.permission_granted).to eq(true) 
+    end
+  end
+
   describe '#files' do
     context 'when there is not subdirectory in current directory' do
       it 'returns all files in current directory' do

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -250,7 +250,7 @@ describe AssignmentParticipant do
     it 'grant publishing rights to one or more assignments using the supplied private key' do
       # create new RSA key-pair 
       key = OpenSSL::PKey::RSA.new 2048
-      participant.public_key = key.public_key.to_pem
+      participant.user.public_key = key.public_key.to_pem
 
       participant.assign_copyright(key.private_key)
       expect(participant.permission_granted).to eq(true) 

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -56,13 +56,4 @@ describe Questionnaire do
     end
   end
 
-  describe '#assign_quiz' do
-    it 'creates a new QuizResponseMap record' do
-      allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
-      expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
-      expect(QuizResponseMap.first.reviewee_id).to eq(1)
-      expect(QuizResponseMap.first.reviewer_id).to eq(2)
-    end
-  end
-
 end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -55,4 +55,14 @@ describe Questionnaire do
       questionnaire.min_question_score = 0
     end
   end
+
+  describe '#assign_quiz' do
+    it 'creates a new QuizResponseMap record' do
+      allow(QuizQuestionnaire).to receive(:find_by).with(instructor_id: 1).and_return(double('QuizQuestionnaire', id: 1))
+      expect { participant.assign_quiz(participant, participant2) }.to change { QuizResponseMap.count }.from(0).to(1)
+      expect(QuizResponseMap.first.reviewee_id).to eq(1)
+      expect(QuizResponseMap.first.reviewer_id).to eq(2)
+    end
+  end
+  
 end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -64,5 +64,5 @@ describe Questionnaire do
       expect(QuizResponseMap.first.reviewer_id).to eq(2)
     end
   end
-  
+
 end


### PR DESCRIPTION
Changes:

* Refactored self.grant_publishing_rights into 'assign_copyright'

* Refactored definition of the method in assignment_participant.rb, removing the participant parameter and participant loop; moving this functionality to wherever the method is called in the application

* Altered functionality of the method call in grant_with_private_key (publishing_controller.rb) and def generate_keys (user.rb) to handle the 'participants.each do' loop 

* Built spec test for modified assign_copyright method in assignment_participant_spec.rb
-- Creates new RSA key-pair for a participant
-- Tests if key matches using assign_copyright
