### PR TITLE
Reviews by reviewer

### DIFF
--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -164,10 +164,6 @@ class AssignmentParticipant < Participant
     ReviewResponseMap.get_assessments_for(self.team)
   end
 
-  def reviews_by_reviewer(reviewer)
-    ReviewResponseMap.get_reviewer_assessments_for(self.team, reviewer)
-  end
-
   def quizzes_taken
     QuizResponseMap.get_assessments_for(self)
   end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -210,13 +210,6 @@ describe AssignmentParticipant do
     end
   end
 
-  describe '#reviews_by_reviewer' do
-    it 'returns corrsponding peer review responses given by certain reviewer' do
-      allow(ReviewResponseMap).to receive(:get_reviewer_assessments_for).with(team, participant).and_return([response])
-      expect(participant.reviews_by_reviewer(participant)).to eq([response])
-    end
-  end
-
   describe '#quizzes_taken' do
     it 'returns corrsponding quiz responses given by current participant' do
       allow(QuizResponseMap).to receive(:get_assessments_for).with(participant).and_return([response])


### PR DESCRIPTION
Changes:

- Issue states to look into the reviews_by_reviewer method and see if it is used/still needed. 
- Determined that all reviews have been of assignment_teams, not assignment_participant
- Determined that reviews_by_reviewer method is only called by collusion_cycle.rb, and Dr. Gehringer checked with Yang regarding the uses of CollusionCycle in the application.
- Determined that CollusionCycle is unused, and thus it is appropriate to make the following changes:
  - Removed method definition from assignment_participant.rb
  - Removed the rspec test for this method from spec/models/assignment_participant_spec.rb

Note: As instructed, I did not change or delete any of the calls in collusion_cycle.rb or collusion_cycle_spec.rb which both call this method several times.

CLOSE #10 