### PR TITLE
E2072. Luke - Review_score 

### DIFF
--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -42,12 +42,6 @@ class AssignmentParticipant < Participant
     reviewers
   end
 
-  def review_score
-    review_questionnaire = self.assignment.questionnaires.select {|q| q.type == "ReviewQuestionnaire" }[0]
-    assessment = review_questionnaire.get_assessments_for(self)
-    (Answer.compute_scores(assessment, review_questionnaire.questions)[:avg] / 100.00) * review_questionnaire.max_possible_score.to_f
-  end
-
   # Return scores that this participant has been given
   # methods extracted from scores method: merge_scores, topic_total_scores, calculate_scores
   def scores(questions)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,5 @@
 class Question < ActiveRecord::Base
   belongs_to :questionnaire # each question belongs to a specific questionnaire
-  belongs_to :review_score  # each review_score pertains to a particular question
   belongs_to :review_of_review_score # ditto
   has_many :question_advices, dependent: :destroy # for each question, there is separate advice about each possible score
   has_many :signup_choices # ?? this may reference signup type questionnaires

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -36,16 +36,6 @@ describe AssignmentParticipant do
     end
   end
 
-  describe '#review_score' do
-    it 'returns the review score' do
-      allow(review_questionnaire).to receive(:get_assessments_for).with(participant).and_return([response])
-      allow(review_questionnaire).to receive(:questions).and_return([question])
-      allow(Answer).to receive(:compute_scores).with([response], [question]).and_return(max: 95, min: 88, avg: 90)
-      allow(review_questionnaire).to receive(:max_possible_score).and_return(5)
-      expect(participant.review_score).to eq(4.5)
-    end
-  end
-
   describe '#scores' do
     before(:each) do
       allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 1, questionnaire_id: 1)


### PR DESCRIPTION
Changes:
- Determined that the only calls to the review_score method in assignment_participant.rb was in collusion_cycle.rb
- After checking with Yang and doing extensive research inside the application, we determined that collusion_cycle.rb is no longer used in the application
- As per these discoveries and conversation with our mentor, I removed this unused method and the associated tests from assignment_participant.rb and assignment_participant_spec.rb, respectively.
