### PR TITLE
Fixed copy method 

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -121,7 +121,7 @@ class ParticipantsController < ApplicationController
     if assignment.course
       course = assignment.course
       assignment.participants.each do |participant|
-        new_participant = participant.copy(course.id)
+        new_participant = participant.copy_to_course(course.id)
         @copied_participants.push new_participant if new_participant
       end
       # only display undo link if copies of participants are created

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -136,7 +136,7 @@ class AssignmentParticipant < Participant
   end
 
   # Copy this participant to a course
-  def copy_participant(course_id)
+  def copy_to_course(course_id)
     CourseParticipant.find_or_create_by(user_id: self.user_id, parent_id: course_id)
   end
 

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -138,9 +138,9 @@ describe AssignmentParticipant do
     end
   end
   
-  describe '#copy_participant' do
+  describe '#copy_to_course' do
     it 'copies assignment participants to a certain course' do
-      expect { participant.copy_participant(123) }.to change { CourseParticipant.count }.from(0).to(1)
+      expect { participant.copy_to_course123) }.to change { CourseParticipant.count }.from(0).to(1)
       expect(CourseParticipant.first.user_id).to eq(2)
       expect(CourseParticipant.first.parent_id).to eq(123)
     end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -140,7 +140,7 @@ describe AssignmentParticipant do
   
   describe '#copy_to_course' do
     it 'copies assignment participants to a certain course' do
-      expect { participant.copy_to_course123) }.to change { CourseParticipant.count }.from(0).to(1)
+      expect { participant.copy_to_course(123) }.to change { CourseParticipant.count }.from(0).to(1)
       expect(CourseParticipant.first.user_id).to eq(2)
       expect(CourseParticipant.first.parent_id).to eq(123)
     end


### PR DESCRIPTION
Resolved a missed call of the old copy method for an AssignmentParticipant. 

Changed name from copy_participant to copy_to_course for clarity. 
